### PR TITLE
Annotate public variables with qualified names and modules

### DIFF
--- a/PySide6-stubs/QtWidgets.pyi
+++ b/PySide6-stubs/QtWidgets.pyi
@@ -7011,7 +7011,7 @@ class QStyleHintReturn(Shiboken.Object):
 
 class QStyleHintReturnMask(PySide6.QtWidgets.QStyleHintReturn):
 
-    region: QRegion
+    region: PySide6.QtGui.QRegion
 
 
     class StyleOptionType(enum.Enum):
@@ -7044,11 +7044,11 @@ class QStyleHintReturnVariant(PySide6.QtWidgets.QStyleHintReturn):
 
 class QStyleOption(Shiboken.Object):
 
-    direction: LayoutDirection
-    fontMetrics: QFontMetrics
-    palette: QPalette
-    rect: QRect
-    state: StateFlag
+    direction: PySide6.QtCore.Qt.LayoutDirection
+    fontMetrics: PySide6.QtGui.QFontMetrics
+    palette: PySide6.QtGui.QPalette
+    rect: PySide6.QtCore.QRect
+    state: PySide6.QtWidgets.QStyle.StateFlag
     type: int
 
 
@@ -7104,9 +7104,9 @@ class QStyleOption(Shiboken.Object):
 
 class QStyleOptionButton(PySide6.QtWidgets.QStyleOption):
 
-    features: ButtonFeature
-    icon: QIcon
-    iconSize: QSize
+    features: PySide6.QtWidgets.QStyleOptionButton.ButtonFeature
+    icon: PySide6.QtGui.QIcon
+    iconSize: PySide6.QtCore.QSize
     text: str
 
 
@@ -7140,13 +7140,13 @@ class QStyleOptionButton(PySide6.QtWidgets.QStyleOption):
 
 class QStyleOptionComboBox(PySide6.QtWidgets.QStyleOptionComplex):
 
-    currentIcon: QIcon
+    currentIcon: PySide6.QtGui.QIcon
     currentText: str
     editable: bool
     frame: bool
-    iconSize: QSize
-    popupRect: QRect
-    textAlignment: AlignmentFlag
+    iconSize: PySide6.QtCore.QSize
+    popupRect: PySide6.QtCore.QRect
+    textAlignment: PySide6.QtCore.Qt.AlignmentFlag
 
 
     class StyleOptionType(enum.Enum):
@@ -7169,8 +7169,8 @@ class QStyleOptionComboBox(PySide6.QtWidgets.QStyleOptionComplex):
 
 class QStyleOptionComplex(PySide6.QtWidgets.QStyleOption):
 
-    activeSubControls: SubControl
-    subControls: SubControl
+    activeSubControls: PySide6.QtWidgets.QStyle.SubControl
+    subControls: PySide6.QtWidgets.QStyle.SubControl
 
 
     class StyleOptionType(enum.Enum):
@@ -7218,7 +7218,7 @@ class QStyleOptionDockWidget(PySide6.QtWidgets.QStyleOption):
 
 class QStyleOptionFocusRect(PySide6.QtWidgets.QStyleOption):
 
-    backgroundColor: QColor
+    backgroundColor: PySide6.QtGui.QColor
 
 
     class StyleOptionType(enum.Enum):
@@ -7241,8 +7241,8 @@ class QStyleOptionFocusRect(PySide6.QtWidgets.QStyleOption):
 
 class QStyleOptionFrame(PySide6.QtWidgets.QStyleOption):
 
-    features: FrameFeature
-    frameShape: Shape
+    features: PySide6.QtWidgets.QStyleOptionFrame.FrameFeature
+    frameShape: PySide6.QtWidgets.QFrame.Shape
     lineWidth: int
     midLineWidth: int
 
@@ -7274,7 +7274,7 @@ class QStyleOptionFrame(PySide6.QtWidgets.QStyleOption):
 
 class QStyleOptionGraphicsItem(PySide6.QtWidgets.QStyleOption):
 
-    exposedRect: QRectF
+    exposedRect: PySide6.QtCore.QRectF
 
 
     class StyleOptionType(enum.Enum):
@@ -7300,12 +7300,12 @@ class QStyleOptionGraphicsItem(PySide6.QtWidgets.QStyleOption):
 
 class QStyleOptionGroupBox(PySide6.QtWidgets.QStyleOptionComplex):
 
-    features: FrameFeature
+    features: PySide6.QtWidgets.QStyleOptionFrame.FrameFeature
     lineWidth: int
     midLineWidth: int
     text: str
-    textAlignment: AlignmentFlag
-    textColor: QColor
+    textAlignment: PySide6.QtCore.Qt.AlignmentFlag
+    textColor: PySide6.QtGui.QColor
 
 
     class StyleOptionType(enum.Enum):
@@ -7328,15 +7328,15 @@ class QStyleOptionGroupBox(PySide6.QtWidgets.QStyleOptionComplex):
 
 class QStyleOptionHeader(PySide6.QtWidgets.QStyleOption):
 
-    icon: QIcon
-    iconAlignment: AlignmentFlag
-    orientation: Orientation
-    position: SectionPosition
+    icon: PySide6.QtGui.QIcon
+    iconAlignment: PySide6.QtCore.Qt.AlignmentFlag
+    orientation: PySide6.QtCore.Qt.Orientation
+    position: PySide6.QtWidgets.QStyleOptionHeader.SectionPosition
     section: int
-    selectedPosition: SelectedPosition
-    sortIndicator: SortIndicator
+    selectedPosition: PySide6.QtWidgets.QStyleOptionHeader.SelectedPosition
+    sortIndicator: PySide6.QtWidgets.QStyleOptionHeader.SortIndicator
     text: str
-    textAlignment: AlignmentFlag
+    textAlignment: PySide6.QtCore.Qt.AlignmentFlag
 
 
     class SectionPosition(enum.Enum):
@@ -7383,7 +7383,7 @@ class QStyleOptionHeader(PySide6.QtWidgets.QStyleOption):
 class QStyleOptionHeaderV2(PySide6.QtWidgets.QStyleOptionHeader):
 
     isSectionDragTarget: bool
-    textElideMode: TextElideMode
+    textElideMode: PySide6.QtCore.Qt.TextElideMode
     unused: int
 
 
@@ -7407,14 +7407,14 @@ class QStyleOptionHeaderV2(PySide6.QtWidgets.QStyleOptionHeader):
 
 class QStyleOptionMenuItem(PySide6.QtWidgets.QStyleOption):
 
-    checkType: CheckType
+    checkType: PySide6.QtWidgets.QStyleOptionMenuItem.CheckType
     checked: bool
-    font: QFont
-    icon: QIcon
+    font: PySide6.QtGui.QFont
+    icon: PySide6.QtGui.QIcon
     maxIconWidth: int
     menuHasCheckableItems: bool
-    menuItemType: MenuItemType
-    menuRect: QRect
+    menuItemType: PySide6.QtWidgets.QStyleOptionMenuItem.MenuItemType
+    menuRect: PySide6.QtCore.QRect
     reservedShortcutWidth: int
     text: str
 
@@ -7464,7 +7464,7 @@ class QStyleOptionProgressBar(PySide6.QtWidgets.QStyleOption):
     minimum: int
     progress: int
     text: str
-    textAlignment: AlignmentFlag
+    textAlignment: PySide6.QtCore.Qt.AlignmentFlag
     textVisible: bool
 
 
@@ -7489,7 +7489,7 @@ class QStyleOptionProgressBar(PySide6.QtWidgets.QStyleOption):
 class QStyleOptionRubberBand(PySide6.QtWidgets.QStyleOption):
 
     opaque: bool
-    shape: Shape
+    shape: PySide6.QtWidgets.QRubberBand.Shape
 
 
     class StyleOptionType(enum.Enum):
@@ -7512,7 +7512,7 @@ class QStyleOptionRubberBand(PySide6.QtWidgets.QStyleOption):
 
 class QStyleOptionSizeGrip(PySide6.QtWidgets.QStyleOptionComplex):
 
-    corner: Corner
+    corner: PySide6.QtCore.Qt.Corner
 
 
     class StyleOptionType(enum.Enum):
@@ -7536,17 +7536,17 @@ class QStyleOptionSizeGrip(PySide6.QtWidgets.QStyleOptionComplex):
 class QStyleOptionSlider(PySide6.QtWidgets.QStyleOptionComplex):
 
     dialWrapping: bool
-    keyboardModifiers: KeyboardModifier
+    keyboardModifiers: PySide6.QtCore.Qt.KeyboardModifier
     maximum: int
     minimum: int
     notchTarget: float
-    orientation: Orientation
+    orientation: PySide6.QtCore.Qt.Orientation
     pageStep: int
     singleStep: int
     sliderPosition: int
     sliderValue: int
     tickInterval: int
-    tickPosition: TickPosition
+    tickPosition: PySide6.QtWidgets.QSlider.TickPosition
     upsideDown: bool
 
 
@@ -7570,9 +7570,9 @@ class QStyleOptionSlider(PySide6.QtWidgets.QStyleOptionComplex):
 
 class QStyleOptionSpinBox(PySide6.QtWidgets.QStyleOptionComplex):
 
-    buttonSymbols: ButtonSymbols
+    buttonSymbols: PySide6.QtWidgets.QAbstractSpinBox.ButtonSymbols
     frame: bool
-    stepEnabled: StepEnabledFlag
+    stepEnabled: PySide6.QtWidgets.QAbstractSpinBox.StepEnabledFlag
 
 
     class StyleOptionType(enum.Enum):
@@ -7595,17 +7595,17 @@ class QStyleOptionSpinBox(PySide6.QtWidgets.QStyleOptionComplex):
 
 class QStyleOptionTab(PySide6.QtWidgets.QStyleOption):
 
-    cornerWidgets: CornerWidget
+    cornerWidgets: PySide6.QtWidgets.QStyleOptionTab.CornerWidget
     documentMode: bool
-    features: TabFeature
-    icon: QIcon
-    iconSize: QSize
-    leftButtonSize: QSize
-    position: TabPosition
-    rightButtonSize: QSize
+    features: PySide6.QtWidgets.QStyleOptionTab.TabFeature
+    icon: PySide6.QtGui.QIcon
+    iconSize: PySide6.QtCore.QSize
+    leftButtonSize: PySide6.QtCore.QSize
+    position: PySide6.QtWidgets.QStyleOptionTab.TabPosition
+    rightButtonSize: PySide6.QtCore.QSize
     row: int
-    selectedPosition: SelectedPosition
-    shape: Shape
+    selectedPosition: PySide6.QtWidgets.QStyleOptionTab.SelectedPosition
+    shape: PySide6.QtWidgets.QTabBar.Shape
     tabIndex: int
     text: str
 
@@ -7659,9 +7659,9 @@ class QStyleOptionTab(PySide6.QtWidgets.QStyleOption):
 class QStyleOptionTabBarBase(PySide6.QtWidgets.QStyleOption):
 
     documentMode: bool
-    selectedTabRect: QRect
-    shape: Shape
-    tabBarRect: QRect
+    selectedTabRect: PySide6.QtCore.QRect
+    shape: PySide6.QtWidgets.QTabBar.Shape
+    tabBarRect: PySide6.QtCore.QRect
 
 
     class StyleOptionType(enum.Enum):
@@ -7684,14 +7684,14 @@ class QStyleOptionTabBarBase(PySide6.QtWidgets.QStyleOption):
 
 class QStyleOptionTabWidgetFrame(PySide6.QtWidgets.QStyleOption):
 
-    leftCornerWidgetSize: QSize
+    leftCornerWidgetSize: PySide6.QtCore.QSize
     lineWidth: int
     midLineWidth: int
-    rightCornerWidgetSize: QSize
-    selectedTabRect: QRect
-    shape: Shape
-    tabBarRect: QRect
-    tabBarSize: QSize
+    rightCornerWidgetSize: PySide6.QtCore.QSize
+    selectedTabRect: PySide6.QtCore.QRect
+    shape: PySide6.QtWidgets.QTabBar.Shape
+    tabBarRect: PySide6.QtCore.QRect
+    tabBarSize: PySide6.QtCore.QSize
 
 
     class StyleOptionType(enum.Enum):
@@ -7714,9 +7714,9 @@ class QStyleOptionTabWidgetFrame(PySide6.QtWidgets.QStyleOption):
 
 class QStyleOptionTitleBar(PySide6.QtWidgets.QStyleOptionComplex):
 
-    icon: QIcon
+    icon: PySide6.QtGui.QIcon
     text: str
-    titleBarFlags: WindowType
+    titleBarFlags: PySide6.QtCore.Qt.WindowType
     titleBarState: int
 
 
@@ -7740,12 +7740,12 @@ class QStyleOptionTitleBar(PySide6.QtWidgets.QStyleOptionComplex):
 
 class QStyleOptionToolBar(PySide6.QtWidgets.QStyleOption):
 
-    features: ToolBarFeature
+    features: PySide6.QtWidgets.QStyleOptionToolBar.ToolBarFeature
     lineWidth: int
     midLineWidth: int
-    positionOfLine: ToolBarPosition
-    positionWithinLine: ToolBarPosition
-    toolBarArea: ToolBarArea
+    positionOfLine: PySide6.QtWidgets.QStyleOptionToolBar.ToolBarPosition
+    positionWithinLine: PySide6.QtWidgets.QStyleOptionToolBar.ToolBarPosition
+    toolBarArea: PySide6.QtCore.Qt.ToolBarArea
 
 
     class StyleOptionType(enum.Enum):
@@ -7782,9 +7782,9 @@ class QStyleOptionToolBar(PySide6.QtWidgets.QStyleOption):
 
 class QStyleOptionToolBox(PySide6.QtWidgets.QStyleOption):
 
-    icon: QIcon
-    position: TabPosition
-    selectedPosition: SelectedPosition
+    icon: PySide6.QtGui.QIcon
+    position: PySide6.QtWidgets.QStyleOptionToolBox.TabPosition
+    selectedPosition: PySide6.QtWidgets.QStyleOptionToolBox.SelectedPosition
     text: str
 
 
@@ -7823,14 +7823,14 @@ class QStyleOptionToolBox(PySide6.QtWidgets.QStyleOption):
 
 class QStyleOptionToolButton(PySide6.QtWidgets.QStyleOptionComplex):
 
-    arrowType: ArrowType
-    features: ToolButtonFeature
-    font: QFont
-    icon: QIcon
-    iconSize: QSize
-    pos: QPoint
+    arrowType: PySide6.QtCore.Qt.ArrowType
+    features: PySide6.QtWidgets.QStyleOptionToolButton.ToolButtonFeature
+    font: PySide6.QtGui.QFont
+    icon: PySide6.QtGui.QIcon
+    iconSize: PySide6.QtCore.QSize
+    pos: PySide6.QtCore.QPoint
     text: str
-    toolButtonStyle: ToolButtonStyle
+    toolButtonStyle: PySide6.QtCore.Qt.ToolButtonStyle
 
 
     class StyleOptionType(enum.Enum):
@@ -7863,21 +7863,21 @@ class QStyleOptionToolButton(PySide6.QtWidgets.QStyleOptionComplex):
 
 class QStyleOptionViewItem(PySide6.QtWidgets.QStyleOption):
 
-    backgroundBrush: QBrush
-    checkState: CheckState
-    decorationAlignment: AlignmentFlag
-    decorationPosition: Position
-    decorationSize: QSize
-    displayAlignment: AlignmentFlag
-    features: ViewItemFeature
-    font: QFont
-    icon: QIcon
-    index: QModelIndex
-    locale: QLocale
+    backgroundBrush: PySide6.QtGui.QBrush
+    checkState: PySide6.QtCore.Qt.CheckState
+    decorationAlignment: PySide6.QtCore.Qt.AlignmentFlag
+    decorationPosition: PySide6.QtWidgets.QStyleOptionViewItem.Position
+    decorationSize: PySide6.QtCore.QSize
+    displayAlignment: PySide6.QtCore.Qt.AlignmentFlag
+    features: PySide6.QtWidgets.QStyleOptionViewItem.ViewItemFeature
+    font: PySide6.QtGui.QFont
+    icon: PySide6.QtGui.QIcon
+    index: PySide6.QtCore.QModelIndex
+    locale: PySide6.QtCore.QLocale
     showDecorationSelected: bool
     text: str
-    textElideMode: TextElideMode
-    viewItemPosition: ViewItemPosition
+    textElideMode: PySide6.QtCore.Qt.TextElideMode
+    viewItemPosition: PySide6.QtWidgets.QStyleOptionViewItem.ViewItemPosition
 
 
     class Position(enum.Enum):
@@ -8581,8 +8581,8 @@ class QTextEdit(PySide6.QtWidgets.QAbstractScrollArea):
 
     class ExtraSelection(Shiboken.Object):
 
-        cursor: QTextCursor
-        format: QTextCharFormat
+        cursor: PySide6.QtGui.QTextCursor
+        format: PySide6.QtGui.QTextCharFormat
 
 
         @overload
@@ -8736,8 +8736,8 @@ class QTextEdit(PySide6.QtWidgets.QAbstractScrollArea):
 
 class QTileRules(Shiboken.Object):
 
-    horizontal: TileRule
-    vertical: TileRule
+    horizontal: PySide6.QtCore.Qt.TileRule
+    vertical: PySide6.QtCore.Qt.TileRule
 
 
     @overload

--- a/scripts/collect_public_variables.py
+++ b/scripts/collect_public_variables.py
@@ -14,7 +14,7 @@ def collect_public_variables_for_module(module_name: str, d: Dict[str, str]) -> 
     print('Processing %s' % module_name)
     try:
         m = importlib.import_module(f'PySide6.{module_name}')
-    except ModuleNotFoundError:
+    except (ModuleNotFoundError, ImportError):
         print('... Module not available!')
         # platform-specific modules can not be imported for example on other platforms
         return
@@ -51,7 +51,10 @@ def collect_public_variables_for_class(class_fqn: str, class_type: Type, d: Dict
             attr_of_instance = getattr(instance, class_attr_name)
             if attr_of_instance == None:
                 continue
-            typename = attr_of_instance.__class__.__name__
+            typename = attr_of_instance.__class__.__qualname__
+            modulename = attr_of_instance.__class__.__module__
+            if modulename != "builtins":
+                typename = f'{modulename}.{typename}'
 
             try:
                 pub_var_dict = d[class_fqn]

--- a/scripts/public-variables.json
+++ b/scripts/public-variables.json
@@ -1,6 +1,224 @@
 {
-    "Qt3DCore.Qt3DCore.QNodeIdTypePair": {
-        "id": "QNodeId"
+    "QtWidgets.QStyleHintReturn": {
+        "version": "int",
+        "type": "int"
+    },
+    "QtWidgets.QStyleHintReturnMask": {
+        "region": "PySide6.QtGui.QRegion"
+    },
+    "QtWidgets.QTileRules": {
+        "horizontal": "PySide6.QtCore.Qt.TileRule",
+        "vertical": "PySide6.QtCore.Qt.TileRule"
+    },
+    "QtWidgets.QTextEdit.ExtraSelection": {
+        "cursor": "PySide6.QtGui.QTextCursor",
+        "format": "PySide6.QtGui.QTextCharFormat"
+    },
+    "QtWidgets.QStyleOption": {
+        "version": "int",
+        "type": "int",
+        "state": "PySide6.QtWidgets.QStyle.StateFlag",
+        "direction": "PySide6.QtCore.Qt.LayoutDirection",
+        "rect": "PySide6.QtCore.QRect",
+        "fontMetrics": "PySide6.QtGui.QFontMetrics",
+        "palette": "PySide6.QtGui.QPalette"
+    },
+    "QtWidgets.QStyleOptionViewItem": {
+        "displayAlignment": "PySide6.QtCore.Qt.AlignmentFlag",
+        "decorationAlignment": "PySide6.QtCore.Qt.AlignmentFlag",
+        "textElideMode": "PySide6.QtCore.Qt.TextElideMode",
+        "decorationPosition": "PySide6.QtWidgets.QStyleOptionViewItem.Position",
+        "decorationSize": "PySide6.QtCore.QSize",
+        "font": "PySide6.QtGui.QFont",
+        "showDecorationSelected": "bool",
+        "features": "PySide6.QtWidgets.QStyleOptionViewItem.ViewItemFeature",
+        "locale": "PySide6.QtCore.QLocale",
+        "index": "PySide6.QtCore.QModelIndex",
+        "checkState": "PySide6.QtCore.Qt.CheckState",
+        "icon": "PySide6.QtGui.QIcon",
+        "text": "str",
+        "viewItemPosition": "PySide6.QtWidgets.QStyleOptionViewItem.ViewItemPosition",
+        "backgroundBrush": "PySide6.QtGui.QBrush"
+    },
+    "QtWidgets.QStyleOptionToolBox": {
+        "text": "str",
+        "icon": "PySide6.QtGui.QIcon",
+        "position": "PySide6.QtWidgets.QStyleOptionToolBox.TabPosition",
+        "selectedPosition": "PySide6.QtWidgets.QStyleOptionToolBox.SelectedPosition"
+    },
+    "QtWidgets.QStyleOptionToolBar": {
+        "positionOfLine": "PySide6.QtWidgets.QStyleOptionToolBar.ToolBarPosition",
+        "positionWithinLine": "PySide6.QtWidgets.QStyleOptionToolBar.ToolBarPosition",
+        "toolBarArea": "PySide6.QtCore.Qt.ToolBarArea",
+        "features": "PySide6.QtWidgets.QStyleOptionToolBar.ToolBarFeature",
+        "lineWidth": "int",
+        "midLineWidth": "int"
+    },
+    "QtWidgets.QStyleOptionTabWidgetFrame": {
+        "lineWidth": "int",
+        "midLineWidth": "int",
+        "shape": "PySide6.QtWidgets.QTabBar.Shape",
+        "tabBarSize": "PySide6.QtCore.QSize",
+        "rightCornerWidgetSize": "PySide6.QtCore.QSize",
+        "leftCornerWidgetSize": "PySide6.QtCore.QSize",
+        "tabBarRect": "PySide6.QtCore.QRect",
+        "selectedTabRect": "PySide6.QtCore.QRect"
+    },
+    "QtWidgets.QStyleOptionTabBarBase": {
+        "shape": "PySide6.QtWidgets.QTabBar.Shape",
+        "tabBarRect": "PySide6.QtCore.QRect",
+        "selectedTabRect": "PySide6.QtCore.QRect",
+        "documentMode": "bool"
+    },
+    "QtWidgets.QStyleOptionTab": {
+        "shape": "PySide6.QtWidgets.QTabBar.Shape",
+        "text": "str",
+        "icon": "PySide6.QtGui.QIcon",
+        "row": "int",
+        "position": "PySide6.QtWidgets.QStyleOptionTab.TabPosition",
+        "selectedPosition": "PySide6.QtWidgets.QStyleOptionTab.SelectedPosition",
+        "cornerWidgets": "PySide6.QtWidgets.QStyleOptionTab.CornerWidget",
+        "iconSize": "PySide6.QtCore.QSize",
+        "documentMode": "bool",
+        "leftButtonSize": "PySide6.QtCore.QSize",
+        "rightButtonSize": "PySide6.QtCore.QSize",
+        "features": "PySide6.QtWidgets.QStyleOptionTab.TabFeature",
+        "tabIndex": "int"
+    },
+    "QtWidgets.QStyleOptionRubberBand": {
+        "shape": "PySide6.QtWidgets.QRubberBand.Shape",
+        "opaque": "bool"
+    },
+    "QtWidgets.QStyleOptionProgressBar": {
+        "minimum": "int",
+        "maximum": "int",
+        "progress": "int",
+        "text": "str",
+        "textAlignment": "PySide6.QtCore.Qt.AlignmentFlag",
+        "textVisible": "bool",
+        "invertedAppearance": "bool",
+        "bottomToTop": "bool"
+    },
+    "QtWidgets.QStyleOptionMenuItem": {
+        "menuItemType": "PySide6.QtWidgets.QStyleOptionMenuItem.MenuItemType",
+        "checkType": "PySide6.QtWidgets.QStyleOptionMenuItem.CheckType",
+        "checked": "bool",
+        "menuHasCheckableItems": "bool",
+        "menuRect": "PySide6.QtCore.QRect",
+        "text": "str",
+        "icon": "PySide6.QtGui.QIcon",
+        "maxIconWidth": "int",
+        "reservedShortcutWidth": "int",
+        "font": "PySide6.QtGui.QFont"
+    },
+    "QtWidgets.QStyleOptionHeader": {
+        "section": "int",
+        "text": "str",
+        "textAlignment": "PySide6.QtCore.Qt.AlignmentFlag",
+        "icon": "PySide6.QtGui.QIcon",
+        "iconAlignment": "PySide6.QtCore.Qt.AlignmentFlag",
+        "position": "PySide6.QtWidgets.QStyleOptionHeader.SectionPosition",
+        "selectedPosition": "PySide6.QtWidgets.QStyleOptionHeader.SelectedPosition",
+        "sortIndicator": "PySide6.QtWidgets.QStyleOptionHeader.SortIndicator",
+        "orientation": "PySide6.QtCore.Qt.Orientation"
+    },
+    "QtWidgets.QStyleOptionHeaderV2": {
+        "textElideMode": "PySide6.QtCore.Qt.TextElideMode",
+        "isSectionDragTarget": "bool",
+        "unused": "int"
+    },
+    "QtWidgets.QStyleOptionGraphicsItem": {
+        "exposedRect": "PySide6.QtCore.QRectF"
+    },
+    "QtWidgets.QStyleOptionFrame": {
+        "lineWidth": "int",
+        "midLineWidth": "int",
+        "features": "PySide6.QtWidgets.QStyleOptionFrame.FrameFeature",
+        "frameShape": "PySide6.QtWidgets.QFrame.Shape"
+    },
+    "QtWidgets.QStyleOptionFocusRect": {
+        "backgroundColor": "PySide6.QtGui.QColor"
+    },
+    "QtWidgets.QStyleOptionDockWidget": {
+        "title": "str",
+        "closable": "bool",
+        "movable": "bool",
+        "floatable": "bool",
+        "verticalTitleBar": "bool"
+    },
+    "QtWidgets.QStyleOptionComplex": {
+        "subControls": "PySide6.QtWidgets.QStyle.SubControl",
+        "activeSubControls": "PySide6.QtWidgets.QStyle.SubControl"
+    },
+    "QtWidgets.QStyleOptionToolButton": {
+        "features": "PySide6.QtWidgets.QStyleOptionToolButton.ToolButtonFeature",
+        "icon": "PySide6.QtGui.QIcon",
+        "iconSize": "PySide6.QtCore.QSize",
+        "text": "str",
+        "arrowType": "PySide6.QtCore.Qt.ArrowType",
+        "toolButtonStyle": "PySide6.QtCore.Qt.ToolButtonStyle",
+        "pos": "PySide6.QtCore.QPoint",
+        "font": "PySide6.QtGui.QFont"
+    },
+    "QtWidgets.QStyleOptionTitleBar": {
+        "text": "str",
+        "icon": "PySide6.QtGui.QIcon",
+        "titleBarState": "int",
+        "titleBarFlags": "PySide6.QtCore.Qt.WindowType"
+    },
+    "QtWidgets.QStyleOptionSpinBox": {
+        "buttonSymbols": "PySide6.QtWidgets.QAbstractSpinBox.ButtonSymbols",
+        "stepEnabled": "PySide6.QtWidgets.QAbstractSpinBox.StepEnabledFlag",
+        "frame": "bool"
+    },
+    "QtWidgets.QStyleOptionSlider": {
+        "orientation": "PySide6.QtCore.Qt.Orientation",
+        "minimum": "int",
+        "maximum": "int",
+        "tickPosition": "PySide6.QtWidgets.QSlider.TickPosition",
+        "tickInterval": "int",
+        "upsideDown": "bool",
+        "sliderPosition": "int",
+        "sliderValue": "int",
+        "singleStep": "int",
+        "pageStep": "int",
+        "notchTarget": "float",
+        "dialWrapping": "bool",
+        "keyboardModifiers": "PySide6.QtCore.Qt.KeyboardModifier"
+    },
+    "QtWidgets.QStyleOptionSizeGrip": {
+        "corner": "PySide6.QtCore.Qt.Corner"
+    },
+    "QtWidgets.QStyleOptionGroupBox": {
+        "features": "PySide6.QtWidgets.QStyleOptionFrame.FrameFeature",
+        "text": "str",
+        "textAlignment": "PySide6.QtCore.Qt.AlignmentFlag",
+        "textColor": "PySide6.QtGui.QColor",
+        "lineWidth": "int",
+        "midLineWidth": "int"
+    },
+    "QtWidgets.QStyleOptionComboBox": {
+        "editable": "bool",
+        "popupRect": "PySide6.QtCore.QRect",
+        "frame": "bool",
+        "currentText": "str",
+        "currentIcon": "PySide6.QtGui.QIcon",
+        "iconSize": "PySide6.QtCore.QSize",
+        "textAlignment": "PySide6.QtCore.Qt.AlignmentFlag"
+    },
+    "QtWidgets.QStyleOptionButton": {
+        "features": "PySide6.QtWidgets.QStyleOptionButton.ButtonFeature",
+        "text": "str",
+        "icon": "PySide6.QtGui.QIcon",
+        "iconSize": "PySide6.QtCore.QSize"
+    },
+    "QtQml.QQmlContext.PropertyPair": {
+        "name": "str"
+    },
+    "QtSensors.qoutputrange": {
+        "minimum": "float",
+        "maximum": "float",
+        "accuracy": "float"
     },
     "Qt3DExtras.Qt3DExtras.QAbstractCameraController.InputState": {
         "rxAxisValue": "float",
@@ -14,78 +232,97 @@
         "altKeyActive": "bool",
         "shiftKeyActive": "bool"
     },
-    "QtBluetooth.QLowEnergyAdvertisingParameters.AddressInfo": {
-        "address": "QBluetoothAddress",
-        "type": "RemoteAddressType"
+    "QtMultimedia.QMediaMetaData": {
+        "data": "dict"
     },
-    "QtCore.QStringConverterBase.State": {
-        "flags": "Flag",
-        "internalState": "int",
-        "remainingChars": "int",
-        "invalidChars": "int"
+    "QtMultimedia.QMediaFormat": {
+        "fmt": "PySide6.QtMultimedia.QMediaFormat.FileFormat",
+        "audio": "PySide6.QtMultimedia.QMediaFormat.AudioCodec",
+        "video": "PySide6.QtMultimedia.QMediaFormat.VideoCodec"
     },
-    "QtCore.QStringConverter": {
-        "state": "State"
+    "QtQuick3D.QQuick3DInstancing.InstanceTableEntry": {
+        "row0": "PySide6.QtGui.QVector4D",
+        "row1": "PySide6.QtGui.QVector4D",
+        "row2": "PySide6.QtGui.QVector4D",
+        "color": "PySide6.QtGui.QVector4D",
+        "instanceData": "PySide6.QtGui.QVector4D"
     },
-    "QtCore.QMessageLogContext": {
-        "version": "int",
-        "line": "int"
-    },
-    "QtCore.QTimeZone.OffsetData": {
-        "abbreviation": "str",
-        "offsetFromUtc": "int",
-        "standardTimeOffset": "int",
-        "daylightTimeOffset": "int"
-    },
-    "QtCore.QJsonParseError": {
+    "QtQuick3D.QQuick3DGeometry.Attribute": {
+        "semantic": "PySide6.QtQuick3D.QQuick3DGeometry.Attribute.Semantic",
         "offset": "int",
-        "error": "ParseError"
+        "componentType": "PySide6.QtQuick3D.QQuick3DGeometry.Attribute.ComponentType"
     },
-    "QtCore.QCborStringResultString": {
-        "data": "str",
-        "status": "StringResultCode"
+    "QtQuick3D.QQuick3DGeometry.TargetAttribute": {
+        "targetId": "int",
+        "attr": "PySide6.QtQuick3D.QQuick3DGeometry.Attribute",
+        "stride": "int"
     },
-    "QtCore.QCborError": {
-        "c": "Code"
+    "QtQuick.QSGGeometry.TexturedPoint2D": {
+        "x": "float",
+        "y": "float",
+        "tx": "float",
+        "ty": "float"
     },
-    "QtCore.QCborParserError": {
-        "offset": "int",
-        "error": "QCborError"
+    "QtQuick.QSGGeometry.Point2D": {
+        "x": "float",
+        "y": "float"
     },
-    "QtCore.QCalendar.YearMonthDay": {
-        "year": "int",
-        "month": "int",
-        "day": "int"
+    "QtQuick.QSGGeometry.ColoredPoint2D": {
+        "x": "float",
+        "y": "float",
+        "r": "int",
+        "g": "int",
+        "b": "int",
+        "a": "int"
     },
-    "QtCore.QByteArray.FromBase64Result": {
-        "decodingStatus": "Base64DecodingStatus"
+    "QtQuick.QSGGeometry.Attribute": {
+        "position": "int",
+        "tupleSize": "int",
+        "type": "int",
+        "isVertexCoordinate": "int",
+        "attributeType": "PySide6.QtQuick.QSGGeometry.AttributeType",
+        "reserved": "int"
     },
-    "QtCore.QCborStringResultByteArray": {
-        "status": "StringResultCode"
+    "QtQuick.QSGGeometry.AttributeSet": {
+        "count": "int",
+        "stride": "int"
+    },
+    "QtQuick.QSGOpaqueTextureMaterial": {
+        "m_filtering": "int",
+        "m_mipmap_filtering": "int",
+        "m_horizontal_wrap": "int",
+        "m_vertical_wrap": "int",
+        "m_anisotropy_level": "int",
+        "m_reserved": "int"
+    },
+    "QtNfc.QNdefFilter.Record": {
+        "typeNameFormat": "PySide6.QtNfc.QNdefRecord.TypeNameFormat",
+        "minimum": "int",
+        "maximum": "int"
     },
     "QtGui.QTextOption.Tab": {
         "position": "float",
-        "type": "TabType",
+        "type": "PySide6.QtGui.QTextOption.TabType",
         "delimiter": "str"
     },
     "QtGui.QPainterPath.Element": {
         "x": "float",
         "y": "float",
-        "type": "ElementType"
+        "type": "PySide6.QtGui.QPainterPath.ElementType"
     },
     "QtGui.QPaintEngineState": {
-        "dirtyFlags": "DirtyFlag"
+        "dirtyFlags": "PySide6.QtGui.QPaintEngine.DirtyFlag"
     },
     "QtGui.QPageRanges.Range": {
-        "from": "int",
+        "from_": "int",
         "to": "int"
     },
     "QtGui.QIconEngine.ScaledPixmapArgument": {
-        "size": "QSize",
-        "mode": "Mode",
-        "state": "State",
+        "size": "PySide6.QtCore.QSize",
+        "mode": "PySide6.QtGui.QIcon.Mode",
+        "state": "PySide6.QtGui.QIcon.State",
         "scale": "float",
-        "pixmap": "QPixmap"
+        "pixmap": "PySide6.QtGui.QPixmap"
     },
     "QtGui.QAccessible.State": {
         "disabled": "int",
@@ -129,7 +366,7 @@
     "QtGui.QTextLayout.FormatRange": {
         "start": "int",
         "length": "int",
-        "format": "QTextCharFormat"
+        "format": "PySide6.QtGui.QTextCharFormat"
     },
     "QtGui.QPainter.PixmapFragment": {
         "x": "float",
@@ -144,91 +381,87 @@
         "opacity": "float"
     },
     "QtGui.QAbstractTextDocumentLayout.Selection": {
-        "cursor": "QTextCursor",
-        "format": "QTextCharFormat"
+        "cursor": "PySide6.QtGui.QTextCursor",
+        "format": "PySide6.QtGui.QTextCharFormat"
     },
     "QtGui.QAbstractTextDocumentLayout.PaintContext": {
         "cursorPosition": "int",
-        "palette": "QPalette",
-        "clip": "QRectF"
+        "palette": "PySide6.QtGui.QPalette",
+        "clip": "PySide6.QtCore.QRectF",
+        "selections": "list"
     },
     "QtHelp.QHelpSearchQuery": {
-        "fieldName": "FieldName",
+        "fieldName": "PySide6.QtHelp.QHelpSearchQuery.FieldName",
         "wordList": "list"
     },
     "QtHelp.QHelpLink": {
-        "url": "QUrl",
+        "url": "PySide6.QtCore.QUrl",
         "title": "str"
     },
-    "QtMultimedia.QMediaMetaData": {
-        "data": "dict"
-    },
-    "QtMultimedia.QMediaFormat": {
-        "fmt": "FileFormat",
-        "audio": "AudioCodec",
-        "video": "VideoCodec"
-    },
-    "QtNfc.QNdefFilter.Record": {
-        "typeNameFormat": "TypeNameFormat",
-        "minimum": "int",
-        "maximum": "int"
-    },
-    "QtQml.QQmlContext.PropertyPair": {
-        "name": "str"
-    },
-    "QtQuick.QSGGeometry.TexturedPoint2D": {
-        "x": "float",
-        "y": "float",
-        "tx": "float",
-        "ty": "float"
-    },
-    "QtQuick.QSGGeometry.Point2D": {
-        "x": "float",
-        "y": "float"
-    },
-    "QtQuick.QSGGeometry.ColoredPoint2D": {
-        "x": "float",
-        "y": "float",
-        "r": "int",
-        "g": "int",
-        "b": "int",
-        "a": "int"
-    },
-    "QtQuick.QSGGeometry.Attribute": {
-        "position": "int",
-        "tupleSize": "int",
-        "type": "int",
-        "isVertexCoordinate": "int",
-        "attributeType": "AttributeType",
-        "reserved": "int"
-    },
-    "QtQuick.QSGGeometry.AttributeSet": {
-        "count": "int",
-        "stride": "int"
-    },
-    "QtQuick.QSGOpaqueTextureMaterial": {
-        "m_filtering": "int",
-        "m_mipmap_filtering": "int",
-        "m_horizontal_wrap": "int",
-        "m_vertical_wrap": "int",
-        "m_anisotropy_level": "int",
-        "m_reserved": "int"
-    },
-    "QtQuick3D.QQuick3DInstancing.InstanceTableEntry": {
-        "row0": "QVector4D",
-        "row1": "QVector4D",
-        "row2": "QVector4D",
-        "color": "QVector4D",
-        "instanceData": "QVector4D"
-    },
-    "QtQuick3D.QQuick3DGeometry.Attribute": {
-        "semantic": "Semantic",
-        "offset": "int",
-        "componentType": "ComponentType"
+    "QtBluetooth.QLowEnergyAdvertisingParameters.AddressInfo": {
+        "address": "PySide6.QtBluetooth.QBluetoothAddress",
+        "type": "PySide6.QtBluetooth.QLowEnergyController.RemoteAddressType"
     },
     "QtRemoteObjects.QRemoteObjectSourceLocationInfo": {
         "typeName": "str",
-        "hostUrl": "QUrl"
+        "hostUrl": "PySide6.QtCore.QUrl"
+    },
+    "QtWebEngineCore.QWebEngineCookieStore.FilterRequest": {
+        "firstPartyUrl": "PySide6.QtCore.QUrl",
+        "origin": "PySide6.QtCore.QUrl",
+        "thirdParty": "bool"
+    },
+    "QtCore.QStringConverterBase.State": {
+        "flags": "PySide6.QtCore.QStringConverterBase.Flag",
+        "internalState": "int",
+        "remainingChars": "int",
+        "invalidChars": "int"
+    },
+    "QtCore.QStringConverter": {
+        "state": "PySide6.QtCore.QStringConverterBase.State"
+    },
+    "QtCore.QMessageLogContext": {
+        "version": "int",
+        "line": "int"
+    },
+    "QtCore.QTimeZone.OffsetData": {
+        "abbreviation": "str",
+        "offsetFromUtc": "int",
+        "standardTimeOffset": "int",
+        "daylightTimeOffset": "int"
+    },
+    "QtCore.QJsonParseError": {
+        "offset": "int",
+        "error": "PySide6.QtCore.QJsonParseError.ParseError"
+    },
+    "QtCore.QProcess.UnixProcessParameters": {
+        "flags": "PySide6.QtCore.QProcess.UnixProcessFlag",
+        "lowestFileDescriptorToClose": "int"
+    },
+    "QtCore.QCborStringResultString": {
+        "data": "str",
+        "status": "PySide6.QtCore.QCborStreamReader.StringResultCode"
+    },
+    "QtCore.QCborError": {
+        "c": "PySide6.QtCore.QCborError.Code"
+    },
+    "QtCore.QCborParserError": {
+        "offset": "int",
+        "error": "PySide6.QtCore.QCborError"
+    },
+    "QtCore.QCalendar.YearMonthDay": {
+        "year": "int",
+        "month": "int",
+        "day": "int"
+    },
+    "QtCore.QByteArray.FromBase64Result": {
+        "decodingStatus": "PySide6.QtCore.QByteArray.Base64DecodingStatus"
+    },
+    "QtCore.QCborStringResultByteArray": {
+        "status": "PySide6.QtCore.QCborStreamReader.StringResultCode"
+    },
+    "Qt3DCore.Qt3DCore.QNodeIdTypePair": {
+        "id": "PySide6.Qt3DCore.Qt3DCore.QNodeId"
     },
     "QtScxml.QScxmlExecutableContent.ParameterInfo": {
         "name": "int",
@@ -258,228 +491,5 @@
         "dest": "int",
         "expr": "int",
         "context": "int"
-    },
-    "QtSensors.qoutputrange": {
-        "minimum": "float",
-        "maximum": "float",
-        "accuracy": "float"
-    },
-    "QtWebEngineCore.QWebEngineCookieStore.FilterRequest": {
-        "firstPartyUrl": "QUrl",
-        "origin": "QUrl",
-        "thirdParty": "bool"
-    },
-    "QtWidgets.QStyleHintReturn": {
-        "version": "int",
-        "type": "int"
-    },
-    "QtWidgets.QStyleHintReturnMask": {
-        "region": "QRegion"
-    },
-    "QtWidgets.QTileRules": {
-        "horizontal": "TileRule",
-        "vertical": "TileRule"
-    },
-    "QtWidgets.QTextEdit.ExtraSelection": {
-        "cursor": "QTextCursor",
-        "format": "QTextCharFormat"
-    },
-    "QtWidgets.QStyleOption": {
-        "version": "int",
-        "type": "int",
-        "state": "StateFlag",
-        "direction": "LayoutDirection",
-        "rect": "QRect",
-        "fontMetrics": "QFontMetrics",
-        "palette": "QPalette"
-    },
-    "QtWidgets.QStyleOptionViewItem": {
-        "displayAlignment": "AlignmentFlag",
-        "decorationAlignment": "AlignmentFlag",
-        "textElideMode": "TextElideMode",
-        "decorationPosition": "Position",
-        "decorationSize": "QSize",
-        "font": "QFont",
-        "showDecorationSelected": "bool",
-        "features": "ViewItemFeature",
-        "locale": "QLocale",
-        "index": "QModelIndex",
-        "checkState": "CheckState",
-        "icon": "QIcon",
-        "text": "str",
-        "viewItemPosition": "ViewItemPosition",
-        "backgroundBrush": "QBrush"
-    },
-    "QtWidgets.QStyleOptionToolBox": {
-        "text": "str",
-        "icon": "QIcon",
-        "position": "TabPosition",
-        "selectedPosition": "SelectedPosition"
-    },
-    "QtWidgets.QStyleOptionToolBar": {
-        "positionOfLine": "ToolBarPosition",
-        "positionWithinLine": "ToolBarPosition",
-        "toolBarArea": "ToolBarArea",
-        "features": "ToolBarFeature",
-        "lineWidth": "int",
-        "midLineWidth": "int"
-    },
-    "QtWidgets.QStyleOptionTabWidgetFrame": {
-        "lineWidth": "int",
-        "midLineWidth": "int",
-        "shape": "Shape",
-        "tabBarSize": "QSize",
-        "rightCornerWidgetSize": "QSize",
-        "leftCornerWidgetSize": "QSize",
-        "tabBarRect": "QRect",
-        "selectedTabRect": "QRect"
-    },
-    "QtWidgets.QStyleOptionTabBarBase": {
-        "shape": "Shape",
-        "tabBarRect": "QRect",
-        "selectedTabRect": "QRect",
-        "documentMode": "bool"
-    },
-    "QtWidgets.QStyleOptionTab": {
-        "shape": "Shape",
-        "text": "str",
-        "icon": "QIcon",
-        "row": "int",
-        "position": "TabPosition",
-        "selectedPosition": "SelectedPosition",
-        "cornerWidgets": "CornerWidget",
-        "iconSize": "QSize",
-        "documentMode": "bool",
-        "leftButtonSize": "QSize",
-        "rightButtonSize": "QSize",
-        "features": "TabFeature",
-        "tabIndex": "int"
-    },
-    "QtWidgets.QStyleOptionRubberBand": {
-        "shape": "Shape",
-        "opaque": "bool"
-    },
-    "QtWidgets.QStyleOptionProgressBar": {
-        "minimum": "int",
-        "maximum": "int",
-        "progress": "int",
-        "text": "str",
-        "textAlignment": "AlignmentFlag",
-        "textVisible": "bool",
-        "invertedAppearance": "bool",
-        "bottomToTop": "bool"
-    },
-    "QtWidgets.QStyleOptionMenuItem": {
-        "menuItemType": "MenuItemType",
-        "checkType": "CheckType",
-        "checked": "bool",
-        "menuHasCheckableItems": "bool",
-        "menuRect": "QRect",
-        "text": "str",
-        "icon": "QIcon",
-        "maxIconWidth": "int",
-        "reservedShortcutWidth": "int",
-        "font": "QFont"
-    },
-    "QtWidgets.QStyleOptionHeader": {
-        "section": "int",
-        "text": "str",
-        "textAlignment": "AlignmentFlag",
-        "icon": "QIcon",
-        "iconAlignment": "AlignmentFlag",
-        "position": "SectionPosition",
-        "selectedPosition": "SelectedPosition",
-        "sortIndicator": "SortIndicator",
-        "orientation": "Orientation"
-    },
-    "QtWidgets.QStyleOptionHeaderV2": {
-        "textElideMode": "TextElideMode",
-        "isSectionDragTarget": "bool",
-        "unused": "int"
-    },
-    "QtWidgets.QStyleOptionGraphicsItem": {
-        "exposedRect": "QRectF"
-    },
-    "QtWidgets.QStyleOptionFrame": {
-        "lineWidth": "int",
-        "midLineWidth": "int",
-        "features": "FrameFeature",
-        "frameShape": "Shape"
-    },
-    "QtWidgets.QStyleOptionFocusRect": {
-        "backgroundColor": "QColor"
-    },
-    "QtWidgets.QStyleOptionDockWidget": {
-        "title": "str",
-        "closable": "bool",
-        "movable": "bool",
-        "floatable": "bool",
-        "verticalTitleBar": "bool"
-    },
-    "QtWidgets.QStyleOptionComplex": {
-        "subControls": "SubControl",
-        "activeSubControls": "SubControl"
-    },
-    "QtWidgets.QStyleOptionToolButton": {
-        "features": "ToolButtonFeature",
-        "icon": "QIcon",
-        "iconSize": "QSize",
-        "text": "str",
-        "arrowType": "ArrowType",
-        "toolButtonStyle": "ToolButtonStyle",
-        "pos": "QPoint",
-        "font": "QFont"
-    },
-    "QtWidgets.QStyleOptionTitleBar": {
-        "text": "str",
-        "icon": "QIcon",
-        "titleBarState": "int",
-        "titleBarFlags": "WindowType"
-    },
-    "QtWidgets.QStyleOptionSpinBox": {
-        "buttonSymbols": "ButtonSymbols",
-        "stepEnabled": "StepEnabledFlag",
-        "frame": "bool"
-    },
-    "QtWidgets.QStyleOptionSlider": {
-        "orientation": "Orientation",
-        "minimum": "int",
-        "maximum": "int",
-        "tickPosition": "TickPosition",
-        "tickInterval": "int",
-        "upsideDown": "bool",
-        "sliderPosition": "int",
-        "sliderValue": "int",
-        "singleStep": "int",
-        "pageStep": "int",
-        "notchTarget": "float",
-        "dialWrapping": "bool",
-        "keyboardModifiers": "KeyboardModifier"
-    },
-    "QtWidgets.QStyleOptionSizeGrip": {
-        "corner": "Corner"
-    },
-    "QtWidgets.QStyleOptionGroupBox": {
-        "features": "FrameFeature",
-        "text": "str",
-        "textAlignment": "AlignmentFlag",
-        "textColor": "QColor",
-        "lineWidth": "int",
-        "midLineWidth": "int"
-    },
-    "QtWidgets.QStyleOptionComboBox": {
-        "editable": "bool",
-        "popupRect": "QRect",
-        "frame": "bool",
-        "currentText": "str",
-        "currentIcon": "QIcon",
-        "iconSize": "QSize",
-        "textAlignment": "AlignmentFlag"
-    },
-    "QtWidgets.QStyleOptionButton": {
-        "features": "ButtonFeature",
-        "text": "str",
-        "icon": "QIcon",
-        "iconSize": "QSize"
     }
 }


### PR DESCRIPTION
This PR aims to finalize PR https://github.com/python-qt-tools/PySide6-stubs/pull/5 by adding qualified names and modules to the types of public variables. For more reference, you can check Issue https://github.com/python-qt-tools/PySide6-stubs/issues/3, and then the discussion on the PR https://github.com/python-qt-tools/PySide6-stubs/pull/5.