### PR TITLE
Moved mypy to dev dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,6 @@ package_dir =
 
 python_requires = >=3.7
 install_requires =
-    mypy>=1.0
     PySide6>=6.0
 
 [options.package_data]
@@ -40,3 +39,4 @@ exclude =
 [options.extras_require]
 dev =
     pytest
+    mypy>=1.0


### PR DESCRIPTION
This PR moves mypy from a general dependency to a dev dependency.
Since the stubs are also useful for other type checkers, this allows the user to decide instead of forcing mypy.

Resolves #17 